### PR TITLE
Add backend for job cancellation.

### DIFF
--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -619,6 +619,15 @@ static void cleanup(void) {
 }
 
 /**
+ * @brief Signal handler--compatible signal declaration.
+ */
+static void cleanup_hndlr(int sig) {
+    (void) sig; // This puts sig into the void.
+    cleanup();
+    exit(1); // Bye
+}
+
+/**
  * @brief Monitors the progression of the child
  *
  * SIGCHLD must be blocked when this function is called.
@@ -833,6 +842,11 @@ int main(int argc, char **argv) {
     sigemptyset(&sigset);
     sigaddset(&sigset, SIGCHLD);
     sigprocmask(SIG_BLOCK, &sigset, NULL);
+
+    // On job cancellation, Tango sends SIGINT to the autograding process.
+    // What better to do than call cleanup?
+    // signal(SIGINT, cleanup_hndlr);
+    (void) cleanup_hndlr;
 
     // output file is written by the child process while running the test.
     // It's created here before forking, because the timestamp thread needs

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -626,6 +626,7 @@ static void cleanup(void) {
     // Kill all of the user's processes
     int ret;
     int try = 0;
+    MESSAGE("Running cleanup");
     // Send a SIGINT first, and give it a couple of seconds
     ret = kill_processes("-INT");
     while (ret == 0) {
@@ -891,8 +892,7 @@ int main(int argc, char **argv) {
 
     // On job cancellation, Tango sends SIGINT to the autograding process.
     // What better to do than call cleanup?
-    // signal(SIGINT, cleanup_hndlr);
-    (void) cleanup_hndlr;
+    signal(SIGINT, cleanup_hndlr);
 
     // output file is written by the child process while running the test.
     // It's created here before forking, because the timestamp thread needs

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -101,10 +101,10 @@ char * getTimestamp(time_t t) {
 #define BUFSIZE         1024
 
 /* Number of time we'll try to kill the grading user's processes */
-#define MAX_KILL_ATTEMPTS   3
+#define MAX_KILL_ATTEMPTS   5
 
 /* Number of seconds to wait in between pkills */
-#define SHUTDOWN_GRACE_TIME 1
+#define SHUTDOWN_GRACE_TIME 3
 
 /**
  * @brief A structure containing all of the user-configurable settings

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -101,10 +101,10 @@ char * getTimestamp(time_t t) {
 #define BUFSIZE         1024
 
 /* Number of time we'll try to kill the grading user's processes */
-#define MAX_KILL_ATTEMPTS   5
+#define MAX_KILL_ATTEMPTS   3
 
 /* Number of seconds to wait in between pkills */
-#define SHUTDOWN_GRACE_TIME 3
+#define SHUTDOWN_GRACE_TIME 1
 
 /**
  * @brief A structure containing all of the user-configurable settings
@@ -915,12 +915,12 @@ int main(int argc, char **argv) {
         ERROR_ERRNO("Unable to fork");
         exit(EXIT_OSERROR);
     } else if (pid == 0) {
+        run_job();
+    } else {
         // On job cancellation, Tango sends SIGINT to the autograding process.
         // What better to do than call cleanup?
         signal(SIGINT, cleanup_hndlr);
 
-        run_job();
-    } else {
         if (close(child_output_fd) < 0) {
             ERROR_ERRNO("Closing output file by parent process");
             // don't quit for this type of error

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -594,6 +594,7 @@ static void cleanup(void) {
     // Kill all of the user's processes
     int ret;
     int try = 0;
+    MESSAGE("Running cleanup");
     // Send a SIGINT first, and give it a couple of seconds
     ret = kill_processes("-INT");
     while (ret == 0) {
@@ -845,8 +846,7 @@ int main(int argc, char **argv) {
 
     // On job cancellation, Tango sends SIGINT to the autograding process.
     // What better to do than call cleanup?
-    // signal(SIGINT, cleanup_hndlr);
-    (void) cleanup_hndlr;
+    signal(SIGINT, cleanup_hndlr);
 
     // output file is written by the child process while running the test.
     // It's created here before forking, because the timestamp thread needs

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -101,10 +101,10 @@ char * getTimestamp(time_t t) {
 #define BUFSIZE         1024
 
 /* Number of time we'll try to kill the grading user's processes */
-#define MAX_KILL_ATTEMPTS   5
+#define MAX_KILL_ATTEMPTS   3
 
 /* Number of seconds to wait in between pkills */
-#define SHUTDOWN_GRACE_TIME 3
+#define SHUTDOWN_GRACE_TIME 1
 
 /**
  * @brief A structure containing all of the user-configurable settings
@@ -481,7 +481,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
  * @arg path Path to program to run
  * @arg argv NULL terminated array of arguments
  */
-static int call_program(char *path, char *argv[]) {
+static int call_program(char *path, char *argv[], char* name) {
     pid_t pid;
     int status;
 
@@ -489,6 +489,12 @@ static int call_program(char *path, char *argv[]) {
         ERROR_ERRNO("Unable to fork");
         exit(EXIT_OSERROR);
     } else if (pid == 0) {
+        if (name) {
+            char filename[50];
+            int fd = open(filename, O_WRONLY, O_CREAT);
+            dup2(fd, STDOUT_FILENO);
+            dup2(fd, STDERR_FILENO);
+        }
         execv(path, argv);
         ERROR_ERRNO("Unable to exec");
         exit(EXIT_OSERROR);
@@ -511,11 +517,11 @@ static void setup_dir(void) {
 
     char *make_args[] = {"make", "setup", NULL};
     bool should_abort = false;
-    if (call_program("/usr/bin/make", make_args) != 0) {
+    if (call_program("/usr/bin/make", make_args, NULL) != 0) {
 	ERROR("Running setup");
 	should_abort = true;
 	char *make_args2[] = {"make", "clean", NULL};
-	if (call_program("/usr/bin/make", make_args2) != 0) {
+	if (call_program("/usr/bin/make", make_args2, NULL) != 0) {
 	    ERROR("Running make clean");
 	    exit(EXIT_OSERROR);
 	}
@@ -528,7 +534,7 @@ static void setup_dir(void) {
 
     if (should_abort) {
 	char *rm_args[] = {"/bin/rm", "-rf", args.directory, NULL};
-	if (call_program("/bin/rm", rm_args) != 0) {
+	if (call_program("/bin/rm", rm_args, NULL) != 0) {
 	    ERROR("Removing directory");
 	    exit(EXIT_OSERROR);
 	}
@@ -538,7 +544,7 @@ static void setup_dir(void) {
     // Move the directory over to the user we're running as's home directory
     char *mv_args[] = {"/bin/mv", "-f", args.directory,
         args.user_info.pw_dir, NULL};
-    if (call_program("/bin/mv", mv_args) != 0) {
+    if (call_program("/bin/mv", mv_args, NULL) != 0) {
         ERROR("Moving directory");
         exit(EXIT_OSERROR);
     }
@@ -553,7 +559,7 @@ static void setup_dir(void) {
     char owner[100];
     sprintf(owner, "%d:%d", args.user_info.pw_uid, args.user_info.pw_gid);
     char *chown_args[] = {"/bin/chown", "-R", owner, args.directory, NULL};
-    if (call_program("/bin/chown", chown_args) != 0) {
+    if (call_program("/bin/chown", chown_args, NULL) != 0) {
         ERROR("Chowning directory");
         exit(EXIT_OSERROR);
     }
@@ -610,7 +616,7 @@ static int kill_processes(char *sig) {
     char *pkill_args[] = {"/usr/bin/pkill", sig, "-u",
         GRADING_USER, NULL};
 
-    if ((ret = call_program("/usr/bin/pkill", pkill_args)) > 1) {
+    if ((ret = call_program("/usr/bin/pkill", pkill_args, "/tmp/pkill.log")) > 1) {
         ERROR("Killing user processes");
         // don't quit.  Let the caller decide
     }
@@ -626,7 +632,6 @@ static void cleanup(void) {
     // Kill all of the user's processes
     int ret;
     int try = 0;
-    MESSAGE("Running cleanup");
     // Send a SIGINT first, and give it a couple of seconds
     ret = kill_processes("-INT");
     while (ret == 0) {
@@ -645,7 +650,7 @@ static void cleanup(void) {
     // in Ubuntu)
     char *find_args[] = {"find", "/usr/bin/find", ".", "/tmp", "/var/tmp", "-user",
         args.user_info.pw_name, "-delete", NULL};
-    if (call_program("/usr/bin/env", find_args) != 0) {
+    if (call_program("/usr/bin/env", find_args, NULL) != 0) {
         ERROR("Deleting user's files");
         exit(EXIT_OSERROR);
     }
@@ -656,6 +661,7 @@ static void cleanup(void) {
  */
 static void cleanup_hndlr(int sig) {
     (void) sig; // This puts sig into the void.
+    MESSAGE("Received cancellation request from user.");
     cleanup();
     exit(1); // Bye
 }
@@ -890,10 +896,6 @@ int main(int argc, char **argv) {
     sigaddset(&sigset, SIGCHLD);
     sigprocmask(SIG_BLOCK, &sigset, NULL);
 
-    // On job cancellation, Tango sends SIGINT to the autograding process.
-    // What better to do than call cleanup?
-    signal(SIGINT, cleanup_hndlr);
-
     // output file is written by the child process while running the test.
     // It's created here before forking, because the timestamp thread needs
     // read access to it.
@@ -913,6 +915,10 @@ int main(int argc, char **argv) {
         ERROR_ERRNO("Unable to fork");
         exit(EXIT_OSERROR);
     } else if (pid == 0) {
+        // On job cancellation, Tango sends SIGINT to the autograding process.
+        // What better to do than call cleanup?
+        signal(SIGINT, cleanup_hndlr);
+
         run_job();
     } else {
         if (close(child_output_fd) < 0) {

--- a/autodriver/autodriver.c
+++ b/autodriver/autodriver.c
@@ -651,6 +651,15 @@ static void cleanup(void) {
 }
 
 /**
+ * @brief Signal handler--compatible signal declaration.
+ */
+static void cleanup_hndlr(int sig) {
+    (void) sig; // This puts sig into the void.
+    cleanup();
+    exit(1); // Bye
+}
+
+/**
  * @brief Monitors the progression of the child
  *
  * SIGCHLD must be blocked when this function is called.
@@ -879,6 +888,11 @@ int main(int argc, char **argv) {
     sigemptyset(&sigset);
     sigaddset(&sigset, SIGCHLD);
     sigprocmask(SIG_BLOCK, &sigset, NULL);
+
+    // On job cancellation, Tango sends SIGINT to the autograding process.
+    // What better to do than call cleanup?
+    // signal(SIGINT, cleanup_hndlr);
+    (void) cleanup_hndlr;
 
     // output file is written by the child process while running the test.
     // It's created here before forking, because the timestamp thread needs

--- a/config.template.py
+++ b/config.template.py
@@ -69,6 +69,7 @@ class Config:
     COPYIN_TIMEOUT = 30
     RUNJOB_TIMEOUT = 60
     COPYOUT_TIMEOUT = 30
+    CANCEL_TIMEOUT = 30
 
     # time zone and timestamp report interval for autodriver execution
     # both are optional.

--- a/config.template.py
+++ b/config.template.py
@@ -69,7 +69,7 @@ class Config:
     COPYIN_TIMEOUT = 30
     RUNJOB_TIMEOUT = 60
     COPYOUT_TIMEOUT = 30
-    CANCEL_TIMEOUT = 30
+    CANCEL_TIMEOUT = 60
 
     # time zone and timestamp report interval for autodriver execution
     # both are optional.

--- a/config.template.py
+++ b/config.template.py
@@ -100,6 +100,9 @@ class Config:
     # How many times to reschedule a failed job
     JOB_RETRIES = 2
 
+    # How many times to try to cancel a job
+    CANCEL_RETRIES = 2
+
     # How many times to attempt an SSH connection
     SSH_RETRIES = 5
 

--- a/jobManager.py
+++ b/jobManager.py
@@ -109,14 +109,13 @@ class JobManager:
                     job.appendTrace("Dispatched job %s:%d [try %d]" %
                                     (job.name, job.id, job.retries))
 
-                    worker = Worker(
+                    Worker(
                         job,
                         vmms,
                         self.jobQueue,
                         self.preallocator,
                         preVM
-                    )
-                    worker.start()
+                    ).start()
 
                 except Exception as err:
                     if job is not None:

--- a/jobManager.py
+++ b/jobManager.py
@@ -109,13 +109,14 @@ class JobManager:
                     job.appendTrace("Dispatched job %s:%d [try %d]" %
                                     (job.name, job.id, job.retries))
 
-                    Worker(
+                    worker = Worker(
                         job,
                         vmms,
                         self.jobQueue,
                         self.preallocator,
                         preVM
-                    ).start()
+                    )
+                    worker.start()
 
                 except Exception as err:
                     if job is not None:

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -157,7 +157,7 @@ class JobQueue:
         DEAD = 3
 
     def findRemovingWaiting(self, p):
-        """ findRemovingLive - find the first job that fulfills the predicate,
+        """ findRemovingWaiting - find the first job that fulfills the predicate,
         favoring the latest-created live job. If the found job is live but
         unrun ("waiting"), move it from the live queue to the dead queue. Always
         return the status of the found job.

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -150,6 +150,54 @@ class JobQueue:
             self.log.error("Job %s not found in queue" % id)
         return status
 
+    class JobStatus:
+        NOT_FOUND = 0
+        WAITING = 1
+        RUNNING = 2
+        DEAD = 3
+
+    def findRemovingWaiting(self, p):
+        """ findRemovingLive - find the first job that fulfills the predicate,
+        favoring the latest-created live job. If the found job is live but
+        unrun ("waiting"), move it from the live queue to the dead queue. Always
+        return the status of the found job.
+        """
+        def firstSatisfying(jobCandidates, status):
+            goodCandidates = [(id, j) for (id, j) in jobCandidates if p(j)]
+            if len(goodCandidates) > 0:
+                id, job = goodCandidates[0]
+                return id, job, status
+            return None, None, JobQueue.JobStatus.NOT_FOUND
+
+        self.queueLock.acquire()
+
+        # Get live jobs in time order, but then reverse when iterating.
+        liveJobs = reversed(sorted(self.liveJobs.iteritems(), key = lambda (_, j): j.tm))
+        liveJobs = list(liveJobs) # I hate python
+
+        def getWaitingJob():
+            liveWaitingJobs = [(id, j) for (id, j) in liveJobs if not j.assigned]
+            return firstSatisfying(liveWaitingJobs, JobQueue.JobStatus.WAITING)
+
+        def getRunningJob():
+            liveAssignedJobs = [(id, j) for (id, j) in liveJobs if j.assigned]
+            return firstSatisfying(liveAssignedJobs, JobQueue.JobStatus.RUNNING)
+
+        def getDeadJob():
+            return firstSatisfying(self.deadJobs.iteritems(), JobQueue.JobStatus.DEAD)
+
+        id, job, status = getWaitingJob()
+        if job == None:
+            id, job, status = getRunningJob()
+        if job == None:
+            id, job, status = getDeadJob()
+
+        if status == JobQueue.JobStatus.WAITING:
+            self.makeDeadUnsafe(id, "Requested by findRemovingLabel")
+
+        self.queueLock.release()
+        return id, job, status
+
     def delJob(self, id, deadjob):
         """ delJob - Implements delJob() interface call
         @param id - The id of the job to remove
@@ -174,6 +222,12 @@ class JobQueue:
             else:
                 self.log.error("Job %s not found in dead queue" % id)
             return status
+    
+    def isLive(self, id):
+        self.queueLock.acquire()
+        isLive = self.liveJobs.get(id)
+        self.queueLock.release()
+        return isLive
 
     def get(self, id):
         """get - retrieve job from live queue
@@ -270,6 +324,13 @@ class JobQueue:
         self.log.info("makeDead| Making dead job ID: " + str(id) + " " + reason)
         self.queueLock.acquire()
         self.log.debug("makeDead| Acquired lock to job queue.")
+        status = self.makeDeadUnsafe(id, reason)
+        self.queueLock.release()
+        self.log.debug("makeDead| Released lock to job queue.")
+        return status
+
+    # Thread unsafe version of makeDead that acquires no locks.
+    def makeDeadUnsafe(self, id, reason):
         status = -1
         if str(id) in self.liveJobs.keys():
             self.log.info("makeDead| Found job ID: %d in the live queue" % (id))
@@ -280,8 +341,6 @@ class JobQueue:
             self.deadJobs.set(id, job)
             self.liveJobs.delete(id)
             job.appendTrace(reason)
-        self.queueLock.release()
-        self.log.debug("makeDead| Released lock to job queue.")
         return status
 
     def getInfo(self):

--- a/restful-tango/server.py
+++ b/restful-tango/server.py
@@ -133,9 +133,9 @@ class ScaleHandler(tornado.web.RequestHandler):
 class CancelHandler(tornado.web.RequestHandler):
 
     @unblock
-    def post(self, key, courseLab, outputFile):
+    def post(self, key, courselab, outputFile):
         """ post - Handles the post request to cancel."""
-        return tangoREST.cancel(key, courseLab, outputFile)
+        return tangoREST.cancel(key, courselab, outputFile)
 
 # Routes
 application = tornado.web.Application([

--- a/restful-tango/server.py
+++ b/restful-tango/server.py
@@ -129,6 +129,14 @@ class ScaleHandler(tornado.web.RequestHandler):
         """ post - Handles the post request to scale."""
         return tangoREST.scale(key, low_water_mark, max_pool_size)
 
+
+class CancelHandler(tornado.web.RequestHandler):
+
+    @unblock
+    def post(self, key, courseLab, outputFile):
+        """ post - Handles the post request to cancel."""
+        return tangoREST.cancel(key, courseLab, outputFile)
+
 # Routes
 application = tornado.web.Application([
     (r"/", MainHandler),
@@ -141,7 +149,8 @@ application = tornado.web.Application([
     (r"/jobs/(%s)/(%s)/" % (SHA1_KEY, DEADJOBS), JobsHandler),
     (r"/pool/(%s)/" % (SHA1_KEY), PoolHandler),
     (r"/prealloc/(%s)/(%s)/(%s)/" % (SHA1_KEY, IMAGE, NUM), PreallocHandler),
-    (r"/scale/(%s)/(%s)/(%s)/" % (SHA1_KEY, NUM, NUM), ScaleHandler)
+    (r"/scale/(%s)/(%s)/(%s)/" % (SHA1_KEY, NUM, NUM), ScaleHandler),
+    (r"/cancel/(%s)/(%s)/(%s)/" % (SHA1_KEY, COURSELAB, OUTPUTFILE), CancelHandler),
 ])
 
 

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -475,6 +475,9 @@ class TangoREST:
             elif ret == -2:
                 self.log.error("The job found with output file %s had already completed, so no job was cancelled." % outputFile)
                 return self.status.job_cancellation_spurious
+            elif ret == -3:
+                self.log.error("The job found with output file %s could not be cancelled" % outputFile)
+                return self.status.job_cancellation_failed
             self.log.info("Successfully cancelled job with output file %s" % outputFile)
             return self.status.job_cancelled
         else:

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -44,6 +44,7 @@ class Status:
         self.invalid_image = self.create(-1, "Invalid image name")
         self.invalid_prealloc_size = self.create(-1, "Invalid prealloc size")
         self.job_cancellation_failed = self.create(-2, "Job cancellation failed")
+        self.job_cancellation_spurious = self.create(-3, "Job cancellation failed because job already completed")
         self.pool_not_found = self.create(-1, "Pool not found")
         self.prealloc_failed = self.create(-1, "Preallocate VM failed")
         self.scale_failed = self.create(-1, "Scale parameters failed to save")
@@ -106,6 +107,12 @@ class TangoREST:
         labPath = self.getDirPath(key, courselab)
         return "%s/%s" % (labPath, self.OUTPUT_FOLDER)
 
+    def getOutFilePath(self, key, courselab, outFile):
+        """ getOutFilePath - Compute output file name.
+        """
+        outPath = self.getOutPath(key, courselab)
+        return "%s/%s" % (outPath, outFile)
+
     def checkFileExists(self, directory, filename, fileMD5):
         """ checkFileExists - Checks if a file exists in a
             directory
@@ -132,15 +139,14 @@ class TangoREST:
             disk=None,
             network=None)
 
-    def convertJobObj(self, dirName, jobObj):
+    def convertJobObj(self, key, courselab, jobObj):
         """ convertJobObj - Converts a dictionary into a TangoJob object
         """
 
         name = jobObj['jobName']
-        outputFile = "%s/%s/%s/%s" % (self.COURSELABS,
-                                      dirName,
-                                      self.OUTPUT_FOLDER,
-                                      jobObj['output_file'])
+        dirPath = self.getDirPath(key, courselab)
+        outputFile = self.getOutFilePath(key, courselab, jobObj['output_file'])
+
         timeout = jobObj['timeout']
         notifyURL = None
         maxOutputFileSize = Config.MAX_OUTPUT_FILE_SIZE
@@ -153,7 +159,7 @@ class TangoREST:
             inFile = file['localFile']
             vmFile = file['destFile']
             handinfile = InputFile(
-                localFile="%s/%s/%s" % (self.COURSELABS, dirName, inFile),
+                localFile="%s/%s" % (dirPath, inFile),
                 destFile=vmFile)
             input.append(handinfile)
 
@@ -305,10 +311,9 @@ class TangoREST:
         self.log.debug("Received addJob request(%s, %s, %s)" %
                        (key, courselab, jobStr))
         if (self.validateKey(key)):
-            labName = self.getDirName(key, courselab)
             try:
                 jobObj = json.loads(jobStr)
-                job = self.convertJobObj(labName, jobObj)
+                job = self.convertJobObj(key, courselab, jobObj)
                 jobId = self.tango.addJob(job)
                 self.log.debug("Done adding job")
                 if (jobId == -1):
@@ -334,12 +339,11 @@ class TangoREST:
         self.log.debug("Received poll request(%s, %s, %s)" %
                        (key, courselab, outputFile))
         if (self.validateKey(key)):
-            outputPath = self.getOutPath(key, courselab)
-            outfilePath = "%s/%s" % (outputPath, outputFile)
-            if os.path.exists(outfilePath):
+            outFilePath = self.getOutFilePath(key, courselab, outputFile)
+            if os.path.exists(outFilePath):
                 self.log.info("Output file (%s, %s, %s) found" %
                               (key, courselab, outputFile))
-                output = open(outfilePath)
+                output = open(outFilePath)
                 result = output.read()
                 output.close()
                 return result
@@ -457,21 +461,20 @@ class TangoREST:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key
 
-    def cancel(self, key, courseLab, outputFile):
+    def cancel(self, key, courselab, outputFile):
         """ cancel - Cancel the job with output file outputfile.
         """
         self.log.debug("Received cancel request(%s, %s)" % (key, outputFile))
         if self.validateKey(key):
-            """
-	    TODO: Actually cancel the worker; don't just delete from the
-            job queue. Also we should probably verify that the job belongs
-            to the provided key.
-            """
-            ret = -1
+            outFilePath = self.getOutFilePath(key, courselab, outputFile)
+            ret = self.tango.cancelJobWithPath(outFilePath)
             # Is this the idiom? IS THIS THE IDIOM???
             if ret == -1:
                 self.log.error("No job was found with output file %s, so no job was cancelled." % outputFile)
                 return self.status.job_cancellation_failed
+            elif ret == -2:
+                self.log.error("The job found with output file %s had already completed, so no job was cancelled." % outputFile)
+                return self.status.job_cancellation_spurious
             self.log.info("Successfully cancelled job with output file %s" % outputFile)
             return self.status.job_cancelled
         else:

--- a/restful-tango/tangoREST.py
+++ b/restful-tango/tangoREST.py
@@ -30,6 +30,7 @@ class Status:
         self.file_uploaded = self.create(0, "Uploaded file")
         self.file_exists = self.create(0, "File exists")
         self.job_added = self.create(0, "Job added")
+        self.job_cancelled = self.create(0, "Job cancelled")
         self.obtained_info = self.create(0, "Found info successfully")
         self.obtained_jobs = self.create(0, "Found list of jobs")
         self.preallocated = self.create(0, "VMs preallocated")
@@ -42,6 +43,7 @@ class Status:
         self.out_not_found = self.create(-1, "Output file not found")
         self.invalid_image = self.create(-1, "Invalid image name")
         self.invalid_prealloc_size = self.create(-1, "Invalid prealloc size")
+        self.job_cancellation_failed = self.create(-2, "Job cancellation failed")
         self.pool_not_found = self.create(-1, "Pool not found")
         self.prealloc_failed = self.create(-1, "Preallocate VM failed")
         self.scale_failed = self.create(-1, "Scale parameters failed to save")
@@ -451,6 +453,27 @@ class TangoREST:
                 return self.status.scale_failed
             self.log.info("Successfully updated scale params")
             return self.status.scale_updated
+        else:
+            self.log.info("Key not recognized: %s" % key)
+            return self.status.wrong_key
+
+    def cancel(self, key, courseLab, outputFile):
+        """ cancel - Cancel the job with output file outputfile.
+        """
+        self.log.debug("Received cancel request(%s, %s)" % (key, outputFile))
+        if self.validateKey(key):
+            """
+	    TODO: Actually cancel the worker; don't just delete from the
+            job queue. Also we should probably verify that the job belongs
+            to the provided key.
+            """
+            ret = -1
+            # Is this the idiom? IS THIS THE IDIOM???
+            if ret == -1:
+                self.log.error("No job was found with output file %s, so no job was cancelled." % outputFile)
+                return self.status.job_cancellation_failed
+            self.log.info("Successfully cancelled job with output file %s" % outputFile)
+            return self.status.job_cancelled
         else:
             self.log.info("Key not recognized: %s" % key)
             return self.status.wrong_key

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -418,7 +418,7 @@ class Ec2SSH:
 
     def kill(self, vm, runTimeout):
         self.log.debug("pkill: Killing job on VM %s" % self.instanceName(vm.id, vm.name))
-        return self.sshWithTimeout(vm, ["/usr/bin/killall", "autodriver"], runTimeout)
+        return self.sshWithTimeout(vm, ["/usr/bin/killall", "-INT", "autodriver"], runTimeout)
 
     def runJob(self, vm, runTimeout, maxOutputFileSize):
         """ runJob - Run the make command on a VM using SSH and

--- a/vmms/ec2SSH.py
+++ b/vmms/ec2SSH.py
@@ -417,8 +417,9 @@ class Ec2SSH:
         return timeout(["ssh"] + self.ssh_flags + [account] + runcmd, runTimeout)
 
     def kill(self, vm, runTimeout):
-        self.log.debug("pkill: Killing job on VM %s" % self.instanceName(vm.id, vm.name))
-        return self.sshWithTimeout(vm, ["/usr/bin/killall", "-INT", "autodriver"], runTimeout)
+        self.log.debug("kill: Killing job on VM %s" % self.instanceName(vm.id, vm.name))
+        # --wait flag means that this will block until all processes die.
+        return self.sshWithTimeout(vm, ["/usr/bin/killall", "--wait", "-INT", "autodriver"], runTimeout)
 
     def runJob(self, vm, runTimeout, maxOutputFileSize):
         """ runJob - Run the make command on a VM using SSH and


### PR DESCRIPTION
Just adds a cancel endpoint that the client can call. Then, we try to kill all autodriver processes on the worker.

I mucked around with trying to cull some duplication in directory names in `tangoREST.py`, but it didn't end up helping too much.